### PR TITLE
Update RNPushNotification.java

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import android.util.Log;
+
 import com.google.firebase.messaging.FirebaseMessaging;
 
 public class RNPushNotification extends ReactContextBaseJavaModule implements ActivityEventListener {
@@ -130,8 +132,12 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
 
         Intent GCMService = new Intent(reactContext, RNPushNotificationRegistrationService.class);
 
-        GCMService.putExtra("senderID", senderID);
-        reactContext.startService(GCMService);
+        try {
+            GCMService.putExtra("senderID", senderID);
+            reactContext.startService(GCMService);
+        } catch (Exception e) {
+            Log.d("EXCEPTION SERVICE::::::", "requestPermissions: " + e);
+        }
     }
     @ReactMethod
     public void subscribeToTopic(String topic) {


### PR DESCRIPTION
This is the same fix for the issue in the sister library to this one: https://github.com/zo0r/react-native-push-notification/pull/809/files Causes a crash if the app is killed and a push notification is sent.