### PR TITLE
Use new npm package PushNotificationIOS outside react-native

### DIFF
--- a/component/index.ios.js
+++ b/component/index.ios.js
@@ -1,12 +1,9 @@
 'use strict';
 
-import {
-  AppState,
-  PushNotificationIOS
-} from 'react-native';
+import { AppState } from 'react-native';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
 
 module.exports = {
   state: AppState,
   component: PushNotificationIOS
 };
-

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     }
   },
   "author": "Calcazar | zo0r <http://zo0r.me>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@react-native-community/push-notification-ios": "^1.0.2"
+  }
 }


### PR DESCRIPTION
Using new package in order to keep the library working in the next react native version